### PR TITLE
Resultstype implemented

### DIFF
--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -872,6 +872,7 @@ class Election(APElection):
 
         self.testresults = kwargs.get('testresults', False)
         self.liveresults = kwargs.get('liveresults', False)
+        self.resultstype = kwargs.get('resultstype')
         self.electiondate = kwargs.get('electiondate', None)
         self.national = kwargs.get('national', None)
         self.api_key = kwargs.get('api_key', None)
@@ -1055,7 +1056,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1075,7 +1076,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=False,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1114,7 +1115,7 @@ class Election(APElection):
             omitResults=False,
             level=self.resultslevel,
             setzerocounts=self.setzerocounts,
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1133,7 +1134,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1155,7 +1156,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             apiKey=self.api_key
         )

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -327,6 +327,7 @@ class CandidateReportingUnit(APElection):
         self.eevp = kwargs.get('eevp', None)
         self.uncontested = kwargs.get('uncontested', False)
         self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultstype', None)
         self.raceid = kwargs.get('raceid', None)
         self.statepostal = kwargs.get('statepostal', None)
         self.statename = kwargs.get('statename', None)
@@ -419,6 +420,7 @@ class CandidateReportingUnit(APElection):
             ('statename', self.statename),
             ('statepostal', self.statepostal),
             ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
             ('votepct', round(self.votepct, PCT_PRECISION)),
@@ -487,6 +489,7 @@ class ReportingUnit(APElection):
 
         self.uncontested = kwargs.get('uncontested', False)
         self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultstype', None)
         self.raceid = kwargs.get('raceid', None)
         self.racetype = kwargs.get('racetype', None)
         self.racetypeid = kwargs.get('racetypeid', None)
@@ -600,6 +603,7 @@ class ReportingUnit(APElection):
             ('statepostal', self.statepostal),
             ('statepostal', self.statepostal),
             ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
         ))
@@ -616,6 +620,7 @@ class Race(APElection):
         self.statepostal = kwargs.get('statePostal', None)
         self.statename = kwargs.get('stateName', None)
         self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultsType', None)
         self.raceid = kwargs.get('raceID', None)
         self.racetype = kwargs.get('raceType', None)
         self.racetypeid = kwargs.get('raceTypeID', None)
@@ -787,6 +792,7 @@ class Race(APElection):
             ('statename', self.statename),
             ('statepostal', self.statepostal),
             ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested)
         ))
 
@@ -1045,7 +1051,8 @@ class Election(APElection):
             ('id', self.id),
             ('electiondate', self.electiondate),
             ('liveresults', self.liveresults),
-            ('testresults', self.testresults)
+            ('testresults', self.testresults),
+            ('resultstype', self.resultstype)
         ))
 
     @property

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -326,7 +326,7 @@ class CandidateReportingUnit(APElection):
         self.precinctsreportingpct = kwargs.get('precinctsreportingpct', 0.0)
         self.eevp = kwargs.get('eevp', None)
         self.uncontested = kwargs.get('uncontested', False)
-        self.resultstype = kwargs.get('resultstype', 'l')
+        self.test = kwargs.get('test', False)
         self.raceid = kwargs.get('raceid', None)
         self.statepostal = kwargs.get('statepostal', None)
         self.statename = kwargs.get('statename', None)
@@ -418,7 +418,7 @@ class CandidateReportingUnit(APElection):
             ('seatnum', self.seatnum),
             ('statename', self.statename),
             ('statepostal', self.statepostal),
-            ('resultstype', self.resultstype),
+            ('test', self.test),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
             ('votepct', round(self.votepct, PCT_PRECISION)),
@@ -486,7 +486,7 @@ class ReportingUnit(APElection):
             self.precinctsreportingpct = kwargs['precinctsreportingpct']
 
         self.uncontested = kwargs.get('uncontested', False)
-        self.resultstype = kwargs.get('resultstype', 'l')
+        self.test = kwargs.get('test', False)
         self.raceid = kwargs.get('raceid', None)
         self.racetype = kwargs.get('racetype', None)
         self.racetypeid = kwargs.get('racetypeid', None)
@@ -599,7 +599,7 @@ class ReportingUnit(APElection):
             ('statename', self.statename),
             ('statepostal', self.statepostal),
             ('statepostal', self.statepostal),
-            ('resultstype', self.resultstype),
+            ('test', self.test),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
         ))
@@ -615,7 +615,7 @@ class Race(APElection):
         self.electiondate = kwargs.get('electiondate', None)
         self.statepostal = kwargs.get('statePostal', None)
         self.statename = kwargs.get('stateName', None)
-        self.resultstype = kwargs.get('resultstype', 'l')
+        self.test = kwargs.get('test', False)
         self.raceid = kwargs.get('raceID', None)
         self.racetype = kwargs.get('raceType', None)
         self.racetypeid = kwargs.get('raceTypeID', None)
@@ -786,7 +786,7 @@ class Race(APElection):
             ('seatnum', self.seatnum),
             ('statename', self.statename),
             ('statepostal', self.statepostal),
-            ('resultstype', self.resultstype),
+            ('test', self.test),
             ('uncontested', self.uncontested)
         ))
 
@@ -870,8 +870,8 @@ class Election(APElection):
         """
         self.id = None
 
+        self.testresults = kwargs.get('testresults', False)
         self.liveresults = kwargs.get('liveresults', False)
-        self.resultstype = kwargs.get('resultstype', 'l')
         self.electiondate = kwargs.get('electiondate', None)
         self.national = kwargs.get('national', None)
         self.api_key = kwargs.get('api_key', None)
@@ -1044,7 +1044,7 @@ class Election(APElection):
             ('id', self.id),
             ('electiondate', self.electiondate),
             ('liveresults', self.liveresults),
-            ('resultstype', self.resultstype)
+            ('testresults', self.testresults)
         ))
 
     @property
@@ -1055,7 +1055,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            resultstype=self.resultstype,
+            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1075,7 +1075,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=False,
             level="ru",
-            resultstype=self.resultstype,
+            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1094,6 +1094,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
+            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1113,7 +1114,7 @@ class Election(APElection):
             omitResults=False,
             level=self.resultslevel,
             setzerocounts=self.setzerocounts,
-            resultstype=self.resultstype,
+            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1132,7 +1133,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            resultstype=self.resultstype,
+            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1154,7 +1155,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            resultstype=self.resultstype,
+            test=self.testresults,
             national=self.national,
             apiKey=self.api_key
         )

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -326,7 +326,7 @@ class CandidateReportingUnit(APElection):
         self.precinctsreportingpct = kwargs.get('precinctsreportingpct', 0.0)
         self.eevp = kwargs.get('eevp', None)
         self.uncontested = kwargs.get('uncontested', False)
-        self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultstype', 'l')
         self.raceid = kwargs.get('raceid', None)
         self.statepostal = kwargs.get('statepostal', None)
         self.statename = kwargs.get('statename', None)
@@ -418,7 +418,7 @@ class CandidateReportingUnit(APElection):
             ('seatnum', self.seatnum),
             ('statename', self.statename),
             ('statepostal', self.statepostal),
-            ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
             ('votepct', round(self.votepct, PCT_PRECISION)),
@@ -486,7 +486,7 @@ class ReportingUnit(APElection):
             self.precinctsreportingpct = kwargs['precinctsreportingpct']
 
         self.uncontested = kwargs.get('uncontested', False)
-        self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultstype', 'l')
         self.raceid = kwargs.get('raceid', None)
         self.racetype = kwargs.get('racetype', None)
         self.racetypeid = kwargs.get('racetypeid', None)
@@ -599,7 +599,7 @@ class ReportingUnit(APElection):
             ('statename', self.statename),
             ('statepostal', self.statepostal),
             ('statepostal', self.statepostal),
-            ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
         ))
@@ -615,7 +615,7 @@ class Race(APElection):
         self.electiondate = kwargs.get('electiondate', None)
         self.statepostal = kwargs.get('statePostal', None)
         self.statename = kwargs.get('stateName', None)
-        self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultstype', 'l')
         self.raceid = kwargs.get('raceID', None)
         self.racetype = kwargs.get('raceType', None)
         self.racetypeid = kwargs.get('raceTypeID', None)
@@ -786,7 +786,7 @@ class Race(APElection):
             ('seatnum', self.seatnum),
             ('statename', self.statename),
             ('statepostal', self.statepostal),
-            ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested)
         ))
 
@@ -870,8 +870,8 @@ class Election(APElection):
         """
         self.id = None
 
-        self.testresults = kwargs.get('testresults', False)
         self.liveresults = kwargs.get('liveresults', False)
+        self.resultstype = kwargs.get('resultstype', 'l')
         self.electiondate = kwargs.get('electiondate', None)
         self.national = kwargs.get('national', None)
         self.api_key = kwargs.get('api_key', None)
@@ -1044,7 +1044,7 @@ class Election(APElection):
             ('id', self.id),
             ('electiondate', self.electiondate),
             ('liveresults', self.liveresults),
-            ('testresults', self.testresults)
+            ('resultstype', self.resultstype)
         ))
 
     @property
@@ -1055,7 +1055,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1075,7 +1075,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=False,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1094,7 +1094,6 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1114,7 +1113,7 @@ class Election(APElection):
             omitResults=False,
             level=self.resultslevel,
             setzerocounts=self.setzerocounts,
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1133,7 +1132,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1155,7 +1154,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             apiKey=self.api_key
         )

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -19,13 +19,15 @@ class ElexBaseController(CementBaseController):
                 help='Election date (e.g. "2015-11-03"; most common date \
 formats accepted).'
             )),
-            (['-t', '--test'], dict(
-                action='store_true',
-                help='Use testing API calls'
-            )),
             (['-n', '--not-live'], dict(
                 action='store_true',
                 help='Do not use live data API calls'
+            )),
+            (['--results-type'], dict(
+                action='store',
+                help='Specify results type. `t` for test, `l` for live, `c` for certified \
+                    `b` for auto switch from live to certified.',
+                default='l'
             )),
             (['-d', '--data-file'], dict(
                 action='store',

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -19,15 +19,13 @@ class ElexBaseController(CementBaseController):
                 help='Election date (e.g. "2015-11-03"; most common date \
 formats accepted).'
             )),
+            (['-t', '--test'], dict(
+                action='store_true',
+                help='Use testing API calls'
+            )),
             (['-n', '--not-live'], dict(
                 action='store_true',
                 help='Do not use live data API calls'
-            )),
-            (['--results-type'], dict(
-                action='store',
-                help='Specify results type. t for test, l for live, c for certified,\
-                    b to automatically switch from live to certified.',
-                default='l'
             )),
             (['-d', '--data-file'], dict(
                 action='store',

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -19,13 +19,15 @@ class ElexBaseController(CementBaseController):
                 help='Election date (e.g. "2015-11-03"; most common date \
 formats accepted).'
             )),
-            (['-t', '--test'], dict(
-                action='store_true',
-                help='Use testing API calls'
-            )),
             (['-n', '--not-live'], dict(
                 action='store_true',
                 help='Do not use live data API calls'
+            )),
+            (['--results-type'], dict(
+                action='store',
+                help='Specify results type. t for test, l for live, c for certified,\
+                    b to automatically switch from live to certified.',
+                default='l'
             )),
             (['-d', '--data-file'], dict(
                 action='store',

--- a/elex/cli/hooks.py
+++ b/elex/cli/hooks.py
@@ -9,7 +9,7 @@ def add_election_hook(app):
     Cache election API object reference after parsing args.
     """
     app.election = Election(
-        testresults=app.pargs.test,
+        resultstype=app.pargs.results_type,
         liveresults=not app.pargs.not_live,
         resultslevel=app.pargs.results_level,
         setzerocounts=app.pargs.set_zero_counts,

--- a/elex/cli/hooks.py
+++ b/elex/cli/hooks.py
@@ -9,8 +9,8 @@ def add_election_hook(app):
     Cache election API object reference after parsing args.
     """
     app.election = Election(
-        testresults=app.pargs.test,
         liveresults=not app.pargs.not_live,
+        resultstype=app.pargs.results_type,
         resultslevel=app.pargs.results_level,
         setzerocounts=app.pargs.set_zero_counts,
         is_test=False,

--- a/elex/cli/hooks.py
+++ b/elex/cli/hooks.py
@@ -9,8 +9,8 @@ def add_election_hook(app):
     Cache election API object reference after parsing args.
     """
     app.election = Election(
+        testresults=app.pargs.test,
         liveresults=not app.pargs.not_live,
-        resultstype=app.pargs.results_type,
         resultslevel=app.pargs.results_level,
         setzerocounts=app.pargs.set_zero_counts,
         is_test=False,

--- a/tests/test_ap_network.py
+++ b/tests/test_ap_network.py
@@ -20,7 +20,7 @@ class APNetworkTestCase(NetworkTestCase):
         response = error.exception.response
         if response.status_code == 403:
             self.skipTest('over quota limit')
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)
 
     @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
     def test_nonexistent_date(self):

--- a/tests/test_candidate_reporting_unit.py
+++ b/tests/test_candidate_reporting_unit.py
@@ -251,6 +251,7 @@ class TestCandidateReportingUnit(tests.ElectionResultsTestCase):
                 'statename',
                 'statepostal',
                 'test',
+                'resultstype',
                 'uncontested',
                 'votecount',
                 'votepct',

--- a/tests/test_candidate_reporting_unit.py
+++ b/tests/test_candidate_reporting_unit.py
@@ -243,6 +243,7 @@ class TestCandidateReportingUnit(tests.ElectionResultsTestCase):
                 'precinctsreporting',
                 'precinctsreportingpct',
                 'precinctstotal',
+                'eevp',
                 'reportingunitid',
                 'reportingunitname',
                 'runoff',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,7 +152,7 @@ class ElexCLICSVTestCase(
         )
         self.assertEqual(
             fields,
-            ['id', 'electiondate', 'liveresults', 'testresults']
+            ['id', 'electiondate', 'liveresults', 'testresults', 'resultstype']
         )
 
     def test_csv_elections_length(self):
@@ -191,7 +191,7 @@ class ElexCLICSVTestCase(
         )
         self.assertEqual(
             fields,
-            ['id', 'electiondate', 'liveresults', 'testresults']
+            ['id', 'electiondate', 'liveresults', 'testresults', 'resultstype']
         )
 
     def test_csv_next_election_length(self):
@@ -424,7 +424,7 @@ class ElexCLIJSONTestCase(
         )
         self.assertEqual(
             fields,
-            ['id', 'electiondate', 'liveresults', 'testresults']
+            ['id', 'electiondate', 'liveresults', 'testresults', 'resultstype']
         )
 
     def test_json_elections_length(self):
@@ -463,7 +463,7 @@ class ElexCLIJSONTestCase(
         )
         self.assertEqual(
             fields,
-            ['id', 'electiondate', 'liveresults', 'testresults']
+            ['id', 'electiondate', 'liveresults', 'testresults', 'resultstype']
         )
 
     def test_json_next_election_length(self):


### PR DESCRIPTION
Adds support for the `resultstype` parameter, which is now required for test results in the AP API. Since `resultstype` is incompatible with the `test` parameter, that has been removed from the API calls. But `test` is still available and correct in the response.